### PR TITLE
Support for SDG API v2

### DIFF
--- a/SDGWebStatistics/Readme.md
+++ b/SDGWebStatistics/Readme.md
@@ -21,7 +21,8 @@ För att pluginet ska fungera måste settings vara satta.
 Endast användare med superadmin-rättigheter kan uppdatera settings.
 De settings som finns är följande:
 - API Key – API-nyckel för authentisering som sätts i headern i api-anropet.
-- API Url – Url:en till apiet.
+- Unique ID Url – URL för att hämta unikt id från SDG som används vid postning av statistik.
+- Statistics URL – URL till SDG för att posta statistik.
 - Site ID – ID:t till siten som statistiken ska tas ifrån. Default är 1.
 - PageTitleIdentifier (Optional) En sträng som används för att identifiera sidorna som ska samlas in. Om denna inte är satt så kommer statistik att samlas in för alla sidor på den valda siten. På FK har vi satt ett meta-fält i headern, <meta name="sdg-tag" content="sdg">, för att identifiera vilka sidor som ingår i SDG och sätter då denna setting till SDG.
 

--- a/SDGWebStatistics/SDGWebStatistics.php
+++ b/SDGWebStatistics/SDGWebStatistics.php
@@ -51,7 +51,7 @@ class SDGWebStatistics extends \Piwik\Plugin
             return;
         }
 
-        $url = $settings->apiUrl->getValue();
+        $url = $settings->statisticsUrl->getValue();
         if (\strpos($aUrl, $url) !== false && $status !== 200) {
             $errorInfo = array(
                 "aUrl" => $aUrl,

--- a/SDGWebStatistics/SystemSettings.php
+++ b/SDGWebStatistics/SystemSettings.php
@@ -31,7 +31,10 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     public $siteId;
 
     /** @var Setting */
-    public $apiUrl;
+    public $uniqueIdUrl;
+
+    /** @var Setting */
+    public $statisticsUrl;
 
     /** @var Setting */
     public $pageTitleIdentifier;
@@ -46,11 +49,12 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     {
         $this->apiKey = $this->createApiKeySetting();
         $this->siteId = $this->createSiteIdSetting();
-        $this->apiUrl = $this->createApiUrlSetting();
+        $this->uniqueIdUrl = $this->createUniqueIdUrlSetting();
+        $this->statisticsUrl = $this->createStatisticsUrlSetting();
         $this->pageTitleIdentifier = $this->createPageTitleIdentifierSetting();
         $this->emailRecipients = $this->createEmailRecipientsSetting();
         
-        $this->mandatoryFields = [ $this->apiKey, $this->siteId, $this->apiUrl ];
+        $this->mandatoryFields = [ $this->apiKey, $this->siteId, $this->uniqueIdUrl, $this->statisticsUrl ];
     }
 
     private function createApiKeySetting()
@@ -78,17 +82,29 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         });
     }
     
-    private function createApiUrlSetting()
+    private function createUniqueIdUrlSetting()
     {
         $default = '';
 
-        return $this->makeSetting('apiUrl', $default, FieldConfig::TYPE_STRING, function (FieldConfig $field) {
-            $field->title = 'API URL';
+        return $this->makeSetting('uniqueIdUrl', $default, FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+            $field->title = 'Unique ID URL';
             $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
-            $field->description = 'URL for SDG-API requests.';
+            $field->description = 'URL to get unique-id from SDG-API.';
             $field->validators[] = new NotEmpty();
         });
     }
+
+    private function createStatisticsUrlSetting()
+        {
+            $default = '';
+
+            return $this->makeSetting('statisticsUrl', $default, FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+                $field->title = 'Statistics URL';
+                $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
+                $field->description = 'URL to post statistics to SDG-API.';
+                $field->validators[] = new NotEmpty();
+            });
+        }
 
     private function createPageTitleIdentifierSetting()
     {
@@ -118,7 +134,11 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     {
         $set = true;
         for ($i = 0; $i <= \count($this->mandatoryFields) - 1 && $set; $i++) {
-            $set = !!$this->mandatoryFields[$i]->getValue();
+            if (!isset($this->mandatoryFields[$i])) {
+                $set = false;
+            } else {
+                $set = !!$this->mandatoryFields[$i]->getValue();
+            }
         }
 
         return $set;

--- a/SDGWebStatistics/services/SendDataToApiService.php
+++ b/SDGWebStatistics/services/SendDataToApiService.php
@@ -83,18 +83,16 @@ class SendDataToApiService
     /**
      * Sends a curl request to the sdgApi
      * 
-     * @param string $path Path to the api request, starting with a "/" eg. /unique-id
+     * @param string $url Path to the api request, starting with a "/" eg. /unique-id
      * @param string $httpMethod Should be "GET" or "POST"
      * @param string|null $requestBody The content that should be sent with a POST request
      * 
      * @return array Containing the result and httpStatus of the request
      */
-    private function sendSdgRequest(string $path, string $httpMethod, string $requestBody = null)    
+    private function sendSdgRequest(string $url, string $httpMethod, string $requestBody = null)
     {
-        $sdgApiUrl = $this->settings->apiUrl->getValue();
         $sdgApiKey = $this->settings->apiKey->getValue();
 
-        $url = $sdgApiUrl . $path;
         $headers = array(
             "x-api-key: " . $sdgApiKey,
             "Content-type: application/json"
@@ -150,7 +148,7 @@ class SendDataToApiService
         if ($requestInfo) {
             $periodId = $requestInfo[SqlService::PERIOD_ID_FIELD];
         } else {
-            $responses[self::UNIQUE_ID_PATH] = $this->sendSdgRequest(self::UNIQUE_ID_PATH, "GET");
+            $responses[self::UNIQUE_ID_PATH] = $this->sendSdgRequest($this->settings->uniqueIdUrl->getValue(), "GET");
             if ($responses[self::UNIQUE_ID_PATH]["status"] == 200) {
                 $periodId = \json_decode($responses[self::UNIQUE_ID_PATH]["data"]);
             }
@@ -162,7 +160,7 @@ class SendDataToApiService
             $referencePeriod = new StatisticsReferencePeriod($periodStart, $periodEnd);
             $requestBody = \json_encode(new StatisticsRequestBody($periodId, $referencePeriod, $sources), \JSON_UNESCAPED_SLASHES);
 
-            $responses[self::INFORMATION_SERVICES_STATISTICS_PATH] = $this->sendSdgRequest(self::INFORMATION_SERVICES_STATISTICS_PATH, "POST", $requestBody);
+            $responses[self::INFORMATION_SERVICES_STATISTICS_PATH] = $this->sendSdgRequest($this->settings->statisticsUrl->getValue(), "POST", $requestBody);
             $httpStatus = $responses[self::INFORMATION_SERVICES_STATISTICS_PATH]["status"];
         } else {
             $periodId = SqlService::PERIOD_ID_MISSING;


### PR DESCRIPTION
På FK så har vi byggt in stöd i pluginet för att konfigurera olika versioner för anropen till SDG för att hämta unikt id och för att posta statistik. Detta då unikt id ligger kvar på v1 men postningen av statistik ska stegas till v2. 

Förutom att bryta upp API URL till 2 nya URLer så har vi också utökat kollen kring obligatoriska fält under inställningar till pluginet. Vi hade lite problem att installera pluginet om inga inställningar fanns för nya fält och var tomma.


![image](https://user-images.githubusercontent.com/54834149/185127536-cf6af64a-fc50-4bfe-b9fb-cca9a7856387.png)
